### PR TITLE
fix(channels): use Twitch access token auth for GET /channels/me/mode…

### DIFF
--- a/src/controllers/channelController.ts
+++ b/src/controllers/channelController.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import type { TwitchPassportUser } from "../strategies/twitchTokenStrategy";
+import type { RequestWithTwitchUser } from "../middlewares/twitchAccessTokenAuth";
 import { dbGatewayService } from "../services/dbGatewayService";
 import { CustomError } from "../middlewares/errorHandler";
 
@@ -91,12 +92,10 @@ export const getModeratedChannels = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const { userId } = req.query;
+    const userId = (req as RequestWithTwitchUser).twitchUser?.id ?? (req.query.userId as string | undefined);
 
-    if (!userId || typeof userId !== "string") {
-      next(
-        new CustomError("Validation failed: Field 'userId' is required", 400),
-      );
+    if (!userId) {
+      next(new CustomError("Validation failed: userId could not be determined", 400));
       return;
     }
 

--- a/src/controllers/channelController.ts
+++ b/src/controllers/channelController.ts
@@ -92,10 +92,14 @@ export const getModeratedChannels = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const userId = (req as RequestWithTwitchUser).twitchUser?.id ?? (req.query.userId as string | undefined);
+    const userId =
+      (req as RequestWithTwitchUser).twitchUser?.id ??
+      (req.query.userId as string | undefined);
 
     if (!userId) {
-      next(new CustomError("Validation failed: userId could not be determined", 400));
+      next(
+        new CustomError("Validation failed: Field 'userId' is required", 400),
+      );
       return;
     }
 

--- a/src/middlewares/twitchAccessTokenAuth.ts
+++ b/src/middlewares/twitchAccessTokenAuth.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from "express";
+import { fetchTwitchUser, type TwitchUser } from "../services/twitchUserService";
+import { config } from "../config/environment";
+import { CustomError } from "./errorHandler";
+import { logger } from "../utils/logger";
+
+export type RequestWithTwitchUser = Request & { twitchUser: TwitchUser };
+
+export const twitchAccessTokenAuth = async (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  if (config.gcp.skipAuth) {
+    logger.debug("Skipping Twitch auth (NODE_ENV=development)");
+    return next();
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    return next(new CustomError("Missing or invalid Authorization header", 401));
+  }
+
+  const accessToken = authHeader.slice(7);
+
+  try {
+    const twitchUser = await fetchTwitchUser(accessToken, config.twitch.clientId);
+    (req as RequestWithTwitchUser).twitchUser = twitchUser;
+    return next();
+  } catch (error) {
+    if (error instanceof CustomError) return next(error);
+    logger.warn("Twitch access token validation failed", {
+      error: error instanceof Error ? error.message : "Unknown",
+    });
+    return next(new CustomError("Unauthorized: invalid Twitch token", 401));
+  }
+};

--- a/src/middlewares/twitchAccessTokenAuth.ts
+++ b/src/middlewares/twitchAccessTokenAuth.ts
@@ -1,5 +1,8 @@
 import { Request, Response, NextFunction } from "express";
-import { fetchTwitchUser, type TwitchUser } from "../services/twitchUserService";
+import {
+  fetchTwitchUser,
+  type TwitchUser,
+} from "../services/twitchUserService";
 import { config } from "../config/environment";
 import { CustomError } from "./errorHandler";
 import { logger } from "../utils/logger";
@@ -18,13 +21,18 @@ export const twitchAccessTokenAuth = async (
 
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
-    return next(new CustomError("Missing or invalid Authorization header", 401));
+    return next(
+      new CustomError("Missing or invalid Authorization header", 401),
+    );
   }
 
   const accessToken = authHeader.slice(7);
 
   try {
-    const twitchUser = await fetchTwitchUser(accessToken, config.twitch.clientId);
+    const twitchUser = await fetchTwitchUser(
+      accessToken,
+      config.twitch.clientId,
+    );
     (req as RequestWithTwitchUser).twitchUser = twitchUser;
     return next();
   } catch (error) {

--- a/src/routes/channelRoute.ts
+++ b/src/routes/channelRoute.ts
@@ -7,6 +7,7 @@ import {
   getModeratedChannels,
 } from "../controllers/channelController";
 import { bffAuthMiddleware } from "../middlewares/bffAuthMiddleware";
+import { twitchAccessTokenAuth } from "../middlewares/twitchAccessTokenAuth";
 import { logger } from "../utils/logger";
 
 const router = Router();
@@ -62,7 +63,7 @@ router.get(
       next(error);
     }
   },
-  bffAuthMiddleware,
+  twitchAccessTokenAuth,
   (req: Request, res: Response, next: NextFunction) => {
     getModeratedChannels(req, res, next).catch(next);
   },

--- a/src/tests/unit/middlewares/twitchAccessTokenAuth.test.ts
+++ b/src/tests/unit/middlewares/twitchAccessTokenAuth.test.ts
@@ -1,0 +1,139 @@
+import { Request, Response } from "express";
+import { twitchAccessTokenAuth } from "../../../middlewares/twitchAccessTokenAuth";
+import { fetchTwitchUser } from "../../../services/twitchUserService";
+import { CustomError } from "../../../middlewares/errorHandler";
+
+jest.mock("../../../services/twitchUserService");
+jest.mock("../../../utils/logger", () => ({
+  logger: { debug: jest.fn(), warn: jest.fn() },
+}));
+jest.mock("../../../config/environment", () => ({
+  config: {
+    gcp: { skipAuth: false },
+    twitch: { clientId: "test-client-id" },
+  },
+}));
+
+const mockFetchTwitchUser = fetchTwitchUser as jest.MockedFunction<
+  typeof fetchTwitchUser
+>;
+
+/* eslint-disable camelcase */
+const mockTwitchUser = {
+  id: "12345",
+  login: "testuser",
+  display_name: "TestUser",
+  type: "",
+  broadcaster_type: "",
+  description: "",
+  profile_image_url: "",
+  offline_image_url: "",
+  created_at: "2020-01-01T00:00:00Z",
+};
+/* eslint-enable camelcase */
+
+const mockNext = jest.fn();
+const mockRes = {} as Response;
+
+describe("twitchAccessTokenAuth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { config } = require("../../../config/environment") as {
+      config: { gcp: { skipAuth: boolean } };
+    };
+    config.gcp.skipAuth = false;
+  });
+
+  it("should call next without validation when skipAuth is true", async () => {
+    const { config } = require("../../../config/environment") as {
+      config: { gcp: { skipAuth: boolean } };
+    };
+    config.gcp.skipAuth = true;
+
+    const req = { headers: {} } as Request;
+    await twitchAccessTokenAuth(req, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith();
+    expect(mockFetchTwitchUser).not.toHaveBeenCalled();
+  });
+
+  it("should call next with 401 when Authorization header is missing", async () => {
+    const req = { headers: {} } as Request;
+
+    await twitchAccessTokenAuth(req, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 401,
+        message: "Missing or invalid Authorization header",
+      }),
+    );
+    expect(mockFetchTwitchUser).not.toHaveBeenCalled();
+  });
+
+  it("should call next with 401 when Authorization header does not start with Bearer", async () => {
+    const req = { headers: { authorization: "Basic sometoken" } } as Request;
+
+    await twitchAccessTokenAuth(req, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 401,
+        message: "Missing or invalid Authorization header",
+      }),
+    );
+    expect(mockFetchTwitchUser).not.toHaveBeenCalled();
+  });
+
+  it("should attach twitchUser to req and call next on valid token", async () => {
+    mockFetchTwitchUser.mockResolvedValueOnce(mockTwitchUser);
+    const req = { headers: { authorization: "Bearer valid-token" } } as Request;
+
+    await twitchAccessTokenAuth(req, mockRes, mockNext);
+
+    expect(mockFetchTwitchUser).toHaveBeenCalledWith(
+      "valid-token",
+      "test-client-id",
+    );
+    expect((req as any).twitchUser).toEqual(mockTwitchUser);
+    expect(mockNext).toHaveBeenCalledWith();
+  });
+
+  it("should propagate CustomError from fetchTwitchUser", async () => {
+    const customError = new CustomError("Failed to connect to Twitch API", 502);
+    mockFetchTwitchUser.mockRejectedValueOnce(customError);
+    const req = { headers: { authorization: "Bearer bad-token" } } as Request;
+
+    await twitchAccessTokenAuth(req, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(customError);
+  });
+
+  it("should call next with 401 on unexpected Error from fetchTwitchUser", async () => {
+    mockFetchTwitchUser.mockRejectedValueOnce(new Error("Network error"));
+    const req = { headers: { authorization: "Bearer bad-token" } } as Request;
+
+    await twitchAccessTokenAuth(req, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 401,
+        message: "Unauthorized: invalid Twitch token",
+      }),
+    );
+  });
+
+  it("should call next with 401 on non-Error rejection from fetchTwitchUser", async () => {
+    mockFetchTwitchUser.mockRejectedValueOnce("unexpected string error");
+    const req = { headers: { authorization: "Bearer bad-token" } } as Request;
+
+    await twitchAccessTokenAuth(req, mockRes, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 401,
+        message: "Unauthorized: invalid Twitch token",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
…rated

bffAuthMiddleware expects a GCP identity token, which browsers cannot generate. This endpoint is called from the frontend with a Twitch OAuth access token. Replace with twitchAccessTokenAuth which validates the token via Twitch /helix/users and attaches the user to the request.